### PR TITLE
specify height in call to internal viewer

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -93,7 +93,7 @@ view_static <- function(x,
   writeLines(whisker.render(template, list(head = head, body = body)),
     con = html_file)
   
-  if (launch) view_app(html_file)
+  if (launch) view_plot(html_file, 600)
   invisible(html_file)
 }
 
@@ -178,18 +178,19 @@ view_dynamic <- function(x,
   
   app <- list(ui = ui, server = server)
   if (launch) {
-    runApp(app, launch.browser = view_app)
+    runApp(app, launch.browser = function(url) view_plot(url, 600))
   } else {
     app
   }
 }
 
-# Check for either a user-specified ggvis.viewapp function or for one provided
-# by the R front-end (RStudio >= v0.98.414 is known to do this, others may as
-# well). Fallback to utils::browseURL if there is no viewapp option provided.
-view_app <- function(url) {
-  viewer <- getOption("ggvis.viewapp", getOption("viewapp", browseURL))
-  viewer(url)
+# View using either an internal viewer or fallback to utils::browseURL
+view_plot <- function(url, height) {
+  viewer <- getOption("viewer")
+  if (!is.null(viewer) && getOption("ggvis.view_internal", TRUE))
+    viewer(url, height)
+  else
+    utils::browseURL(url)
 }
 
 


### PR DESCRIPTION
Formerly the RStudio Viewer pane maximized to take all available vertical space. This was problematic especially for the case of users configured with the Console in the top-right pane. As of RStudio v0.98.423 the viewer function takes an additional height parameter that can be used to request a desired height (excluding the parameter simply uses the current pane height). RStudio will attempt to provide the requested height subject to the constraint of the opposing pane staying at least 160 pixels high (7 lines of text in the Console).

This change hard-codes the requested height to 600 pixels (about what's currently necessary to show a ggvis plot without extra interaction controls). There are two additional refinements we'll ultimately want to make:
- Request less space once we've hidden the standard renderer/download controls. I did some testing and discovered that on an 800 pixel high monitor the ideal height is about 400 pixels so this is probably a good number to shoot for.
- Request some additional space for interaction controls when they are present. We'll also want to do some work to minimize how much vertical space is occupied by interaction controls (e.g. by trying to get two controls per line).

Note that if a height request can't be satisfied there are two possible remedies: (1) ggvis could detect the window height and scale the plot down accordingly; or (2) The window could be allowed to scroll which would serve as a prompt for the user to manually resize the pane as they see fit.

One other change here is the querying of the ggvis.view_internal option to allow the user to specify that they always want plots viewed in an external browser. Wasn't exactly sure how to integrate this with the new opts() function but it seems like this would be desirable.
