### PR TITLE
Add quiet option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Imports:
     whisker,
     RJSONIO,
     digest,
-    shiny (>= 0.6.0.99)
+    shiny (>= 0.8.0.99)
 Suggests:
     testthat (>= 0.7.1.99),
     knitr

--- a/R/print.R
+++ b/R/print.R
@@ -13,6 +13,8 @@
 #' @param launch If \code{TRUE}, launch this web page in a browser.
 #' @param port the port on which to start the shiny app. If NULL (the default),
 #'   Shiny will select a random port.
+#' @param quiet If \code{TRUE} show status messages from Shiny. (Default is
+#'   \code{FALSE}.)
 #' @keywords internal
 #' @method print ggvis
 #' @export
@@ -140,7 +142,7 @@ copy_www_resources <- function(destdir) {
 #' @importFrom shiny basicPage uiOutput mainPanel tags observe runApp stopApp renderUI
 view_dynamic <- function(x, 
                          renderer = getOption("ggvis.renderer", default="canvas"), 
-                         launch = TRUE, port = NULL) {
+                         launch = TRUE, port = NULL, quiet = TRUE) {
   
   if (!(renderer %in% c("canvas", "svg")))
     stop("renderer must be 'canvas' or 'svg'")
@@ -181,7 +183,8 @@ view_dynamic <- function(x,
     # two on a row.
     height <- 350 + 70 * ceiling(n_controls / 2)
 
-    runApp(app, port = port, launch.browser = function(url) view_plot(url, height))
+    runApp(app, port = port, quiet = quiet,
+           launch.browser = function(url) view_plot(url, height))
   } else {
     app
   }

--- a/man/print.ggvis.Rd
+++ b/man/print.ggvis.Rd
@@ -12,7 +12,7 @@
 
   view_dynamic(x,
     renderer = getOption("ggvis.renderer", default = "canvas"),
-    launch = TRUE, port = NULL)
+    launch = TRUE, port = NULL, quiet = TRUE)
 }
 \arguments{
   \item{x}{A ggvis object.}
@@ -30,6 +30,9 @@
 
   \item{port}{the port on which to start the shiny app. If
   NULL (the default), Shiny will select a random port.}
+
+  \item{quiet}{If \code{TRUE} show status messages from
+  Shiny. (Default is \code{FALSE}.)}
 }
 \description{
   \code{view_static} creates a static web page in a


### PR DESCRIPTION
This adds a quiet option - I'm holding off from merging for now, since it needs the latest development version of Shiny.

Previously we used `suppressWarnings` but that also suppressed useful messages from the auto-generated Shiny app.
