### PR TITLE
Update control output to use Shiny's new renderHtml function

### DIFF
--- a/inst/www/js/shiny-ggvis.js
+++ b/inst/www/js/shiny-ggvis.js
@@ -35,10 +35,16 @@ $(function(){ //DOM Ready
       this.renderError(el, err);
     },
     renderValue: function(el, data) {
-      var $el = $(el);
-
       Shiny.unbindAll(el);
-      $el.html(data);
+
+      var html;
+      if (data === null) {
+        html = '';
+      } else {
+        html = data;
+      }
+
+      Shiny.renderHtml(html, el);
       Shiny.initializeInputs(el);
       Shiny.bindAll(el);
 


### PR DESCRIPTION
This fixes the issue with sliders not appearing correctly when `input_slider` is used. Holding off on merging this until after rstudio/shiny#376 is merged into Shiny.
