### PR TITLE
fix ggvis #129

### DIFF
--- a/R/linked-brush.R
+++ b/R/linked-brush.R
@@ -65,7 +65,7 @@ as.reactive.reactive_proxy <- function(x, session = NULL, ...) {
     if (length(keys) == 0) {
       x$rv$keys <- NULL
     } else {
-      x$rv$keys <- keys + 1
+      x$rv$keys <- keys
     }
   })
   session$onSessionEnded(function() {


### PR DESCRIPTION
Don't know what this "+ 1" was supposed to do. When I made it not crash by converting keys to numeric, it selected the wrong objects in the linked plot. Without + 1 it works as expected.
