### PR TITLE
Fix timeout for dynamic demo

### DIFF
--- a/demo/dynamic.r
+++ b/demo/dynamic.r
@@ -12,7 +12,7 @@ ggvis(mtc1, props(x = ~wt, y = ~mpg)) + layer_point()
 df <- data.frame(x = runif(20), y = runif(20))
 # Basic dynamic example
 mtc1 <- reactive({
-  invalidateLater(20, NULL);
+  invalidateLater(200, NULL);
 
   df$x <<- df$x + runif(20, -0.05, 0.05)
   df$y <<- df$y + runif(20, -0.05, 0.05)


### PR DESCRIPTION
Fix the timeout for the reactive demo so that it actually works (previous one was too low so the display could not draw in time).
