### PR TITLE
Move dplyr ahead in install_github

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ggvis is not yet available on CRAN. You can install it from github with the foll
 
 ```R
 # install.packages("devtools")
-devtools::install_github(c("rstudio/shiny", "rstudio/ggvis", "hadley/dplyr"),
+devtools::install_github(c("rstudio/shiny", "hadley/dplyr", "rstudio/ggvis"),
   build_vignettes = FALSE)
 ```
 


### PR DESCRIPTION
ggvis will fail to install because of insufficient dplyr version. Need to move dplyr ahead so it gets installed before attempting ggvis itself.
