### PR TITLE
Do not show tooltip if result of html function is NULL

### DIFF
--- a/R/interact_tooltip.R
+++ b/R/interact_tooltip.R
@@ -31,7 +31,7 @@ add_tooltip <- function(vis, html, on = c("hover", "click")) {
     html <- html(data)
     if (is.null(html)) {
       hide_tooltip(session)
-    }else{
+    } else {
       show_tooltip(session, location$x + 5, location$y + 5, html)
     }
   }


### PR DESCRIPTION
This prevents showing blank tooltip and also enables a way to hide tooltip at will within the `html` function for `add_tooltip`.

For example, the following will only show tooltip for points but not for text because text doesn't have direction

```
ggvis(data = NULL, x = ~long, y = ~lat) %>%
  layer_points(size = ~survivors, stroke = ~direction, data = Minard.troops) %>%
  layer_text(text := ~city, dx := 5, dy := -5, data = Minard.cities) %>% 
  add_tooltip(function(df){df$direction})
```
