### PR TITLE
Scale datetime domain approriately

### DIFF
--- a/R/scale_info.R
+++ b/R/scale_info.R
@@ -13,7 +13,7 @@ scale_info <- function(prop, data) {
 collapse_scale_infos <- function(infos) {
   if (empty(infos)) return(NULL)
 
-  domains <- lapply(infos, function(info) info$domain)
+  domains <- lapply(infos, function(info) format_vec_d3json(info$domain))
   domain <- data_range(unlist(domains, recursive = FALSE))
 
   structure(list(


### PR DESCRIPTION
When domains are of type datetime, the `unlist` operation automatically coerce the values into timestamps in seconds. Using `format_vec_d3json` to proactively cast datatype before range calculation.

Quick example to reproduce the problem:

```
library(lubridate)
view_dynamic(data.frame(date=ymd(20140101)+months(1:5), value=runif(5)) %>% 
ggvis(~date, ~value) %>% 
layer_points() %>% 
set_dscale("x", "datetime", nice="month"))
```

Let me know if you have any suggestions or concerns. Also I can probably get CLA back to you guys by Friday.
