### PR TITLE
Prevent shiny-ggvis.js from throwing when loaded from non-Shiny app

### DIFF
--- a/inst/www/ggvis/js/shiny-ggvis.js
+++ b/inst/www/ggvis/js/shiny-ggvis.js
@@ -4,6 +4,11 @@
 /*global Shiny, ggvis, vg*/
 $(function(){ //DOM Ready
 
+  // This file can be loaded even in non-Shiny contexts. If so, abort; there's
+  // nothing useful we can do.
+  if (!window.Shiny)
+    return;
+
   var _ = window.lodash;
 
   var ggvisOutputBinding = new Shiny.OutputBinding();


### PR DESCRIPTION
knit_print.ggvis always seems to cause shiny-ggvis.js to get loaded,
even if used in a non-Shiny context. This change allows shiny-ggvis.js
to be safely loaded no matter what the context. The alternative would
be to be more careful about when shiny-ggvis.js is loaded; I couldn't
immediately figure out a good way to do that. It seems weird that
the static rendering codepaths should use ggvisOutput, but I assume
that was done (by me??) for a reason.
