### PR TITLE
Fixed a bug in mouseOffset() with Firefox, which lacks event.offsetX/Y properties

### DIFF
--- a/inst/www/ggvis/js/ggvis.js
+++ b/inst/www/ggvis/js/ggvis.js
@@ -799,10 +799,13 @@ ggvis = (function(_) {
 
       // Internal functions --------------------------------------------
       function mouseOffset(e) {
-        if (e.offsetX == undefined) {
+        // A workaround for Firefox, which doesn't provide offsetX/Y
+        // for mouse event.
+        if (typeof(e.offsetX) === "undefined") {
+          var offset = $(e.currentTarget).offset();
           return {
-            x: e.pageX - $(e.currentTarget).offset().left,
-            y: e.pageY - $(e.currentTarget).offset().top
+            x: e.pageX - offset.left,
+            y: e.pageY - offset.top
           };
         }
         else {


### PR DESCRIPTION
This commit addresses the issue with ggvis interactivity in Firefox, mostly with mouse clicking and dragging.
The current internal function mouseOffset() uses event.offsetX/Y which are undefined in Firefox, causing link_brush() to function abnormally. 

This commit should fix that.
