### PR TITLE
Force as.character(html) in show_tooltip

### DIFF
--- a/R/interact_tooltip.R
+++ b/R/interact_tooltip.R
@@ -71,7 +71,7 @@ add_tooltip <- function(vis, html, on = c("hover", "click")) {
 #' @export
 show_tooltip <- function(session, l = 0, t = 0, html = "") {
   ggvis_message(session, "show_tooltip",
-    list(pagex = l, pagey = t, html = html))
+    list(pagex = l, pagey = t, html = as.character(html)))
 }
 
 #' @rdname show_tooltip


### PR DESCRIPTION
.... to ensure `shiny.tag` objects get displayed properly.

In particular, [read about the problem more in detail at StackOverflow](http://stackoverflow.com/questions/25070302/shiny-ggvis-and-add-tooltip-with-html/25072743#25072743).

Note the incorrect tooltip in the screenshot below.

![screen shot 2014-07-31 at 11 22 31 pm](https://cloud.githubusercontent.com/assets/1638492/3774757/7f1653ee-1933-11e4-8c80-9b9de40887d6.png)

versus the expect output

![screen shot 2014-07-31 at 11 23 15 pm](https://cloud.githubusercontent.com/assets/1638492/3774761/91a46960-1933-11e4-8acf-fe216b386cbc.png)
