### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Install the latest development version with:
 
 ```R
 # install.packages("devtools")
-devtools::install_github("hadley/lazy", build_vignettes = FALSE)
+devtools::install_github("hadley/lazyeval", build_vignettes = FALSE)
 devtools::install_github("hadley/dplyr", build_vignettes = FALSE)
 devtools::install_github("rstudio/ggvis", build_vignettes = FALSE)
 ```


### PR DESCRIPTION
I see that the `lazy` package name has changed to `lazyeval`
