### PR TITLE
Assign reactive_id when broker is created

### DIFF
--- a/R/broker.R
+++ b/R/broker.R
@@ -36,6 +36,10 @@ create_broker <- function(r, controls = NULL, connect = NULL, spec = NULL) {
     spec = spec
   ))
 
+  if (is.null(reactive_id(r))) {
+    reactive_id(r) <- rand_id("reactive_")
+  }
+
   r
 }
 

--- a/R/prop.R
+++ b/R/prop.R
@@ -124,7 +124,11 @@ new_prop.default <- function(x, property, scale, offset, mult, env, event,
 #' @export
 new_prop.reactive <- function(x, property, scale, offset, mult, env, event,
                               label) {
-  reactive_id(x) <- rand_id("reactive_")
+
+  if (is.null(reactive_id(x))) {
+    reactive_id(x) <- rand_id("reactive_")
+  }
+
   structure(
     list(
       property = property,


### PR DESCRIPTION
This assigns a `reactive_id` when a broker is created, instead of when a prop is created from the broker. Fixes #192.

@hadley, do you see any issues with this?
