### PR TITLE
compute_bin: unclass factors for histogram width. Fixes #361

### DIFF
--- a/R/compute_bin.R
+++ b/R/compute_bin.R
@@ -84,7 +84,13 @@ compute_bin.data.frame <- function(x, x_var, w_var = NULL, width = NULL,
   } else {
     w_val <- eval_vector(x, w_var)
   }
-
+  
+  # If x_val is a factor, unclass and use bin_vector.numeric for 
+  # width dimensions.
+  if (is.factor(x_val)) {
+    x_val <- as.numeric(unclass(x_val))
+  }
+  
   bin_vector(x_val, weight = w_val, width = params$width,
              origin = params$origin, closed = params$closed, pad = pad)
 }

--- a/R/utils_data.R
+++ b/R/utils_data.R
@@ -206,5 +206,10 @@ range2 <- function(..., na.rm = FALSE) {
   if (length(vals) == 0) {
     return(vals)
   }
+  
+  # If vals is a factor, unclass before calling range
+  if (is.factor(...)) {
+    return(range(unclass(...)))
+  }
   range(..., na.rm = na.rm)
 }

--- a/tests/testthat/test-compute-bin.r
+++ b/tests/testthat/test-compute-bin.r
@@ -199,3 +199,21 @@ test_that("only NA, one row of output", {
   expect_equal(binned$x_, NA)
 })
 
+# Factor on x axis
+
+test_that("take x axis factor and unclass to numeric", {
+  input = data.frame(c=rep(c("c1","c2","c3"),each=3), 
+                  q=rep(c("q1","q2","q3"), 3, each=4), 
+                  v=1:4)
+  output = data.frame(count_ = c(12.0, 0.0 ,12.0, 0.0, 12.0), x_ = seq(1, 3, by = 0.5),
+                      xmin_ = seq(0.75, 2.75, by = 0.5), xmax_ = seq(1.25, 3.25, by = 0.5),
+                      width_ = rep(0.5, 5))
+  x_var_test <- as.formula("~c")
+  expect_equal(compute_bin(input, x_var_test, w_var=NULL,
+                           width = 0.5,
+                           center = NULL, boundary = NULL,
+                           closed = c("right", "left"), pad = FALSE), 
+               output)
+})
+
+


### PR DESCRIPTION
When factors are passed to ggvis x-axis the bin_vector function fails
as range does not work on factors.  Added if/else statements in
compute_bin and range2 functions uncles the factor before returning.

Test added to test-compute-bin.r to verify proper return values.  Issue
#363 prevents full run of testhtat.R, but manual tests pass.
