### PR TITLE
Identify plots as htmlwidget, link to showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
  
 ggvis is currently dormant. We fundamentally believe in the ideas that underlie ggvis: reactive programming is the right foundation for interactive visualisation. However, we are not currently working on ggvis because we do not see it as the most pressing issue for the R community as you can only use interactive graphics once you've successfuly tackled the rest of the data analysis process.
 
-We hope to come back to ggvis in the future; in the meantime you might want to try out [plotly](https://plot.ly/ggplot2/getting-started/) or creating inteactive graphics [with shiny](https://blog.rstudio.com/2015/06/16/shiny-0-12-interactive-plots-with-ggplot2/).
+We hope to come back to ggvis in the future; in the meantime you can create interactive visualisations with htmlwidget packages, including [plotly](http://www.htmlwidgets.org/showcase_plotly.html), or create your own interactive graphics with [shiny](https://blog.rstudio.com/2015/06/16/shiny-0-12-interactive-plots-with-ggplot2/).
 
 ## Introduction
 


### PR DESCRIPTION
The plotly library is one of many htmlwidgets, it likely will not solve every user's needs. Linking to the htmlwidgets showcase provides users with more alternatives until ggvis is available.

---
Note: I've previously signed the individual contributor agreement.