### PR TITLE
Using dplyr::bind_rows() instead of dplyr::rbind_all()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     jsonlite (>= 0.9.11),
     shiny (>= 0.11.1),
     magrittr,
-    dplyr (>= 0.4.0),
+    dplyr (>= 0.5.0),
     lazyeval,
     htmltools (>= 0.2.4),
     methods

--- a/R/handle_brush.R
+++ b/R/handle_brush.R
@@ -80,7 +80,7 @@ tidy_items <- function(items) {
     attr(x, "row.names") <- .set_row_names(1L)
     x
   })
-  items <- dplyr::rbind_all(dfs)
+  items <- dplyr::bind_rows(dfs)
 
   if (is.numeric(items$key__)) {
     items$key__ <- as.character(items$key__ + 1)


### PR DESCRIPTION
We're https://github.com/tidyverse/dplyr/issues/4579 in the process of releasing dplyr 0.8.4 and this package fail at our reverse dependency checks because the `dplyr::rbind_all()` function has been formally removed after being deprecated for many versions. 

We might revert that decision because it affects a handful of packages, but in any case even if `rbind_all()` stays a little longer, you still should use `bind_rows()` instead. 

````
# ggvis

<details>

* Version: 0.4.4
* Source code: https://github.com/cran/ggvis
* URL: http://ggvis.rstudio.com/
* Date/Publication: 2018-09-28 21:50:03 UTC
* Number of recursive dependencies: 53

Run `revdep_details(,"ggvis")` for more info

</details>

## Newly broken

*   checking dependencies in R code ... NOTE
    ```
    Missing or unexported object: ‘dplyr::rbind_all’
    ```

````